### PR TITLE
Super WIP runOnWorker proposal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,7 @@ class TaskInfo extends AsyncResource implements Task {
     return ret;
   }
 
-  done (err : Error | null, result? : any) : void {
+  done (err : any, result? : any) : void {
     this.runInAsyncScope(this.callback, null, err, result);
     this.emitDestroy(); // `TaskInfo`s are used only once.
     // If an abort signal was used, remove the listener from it when
@@ -475,7 +475,7 @@ class WorkerInfo extends AsynchronouslyCreatedResource {
 
     try {
       this.port.postMessage(message, taskInfo.transferList);
-    } catch (err: any) {
+    } catch (err) {
       // This would mostly happen if e.g. message contains unserializable data
       // or transferList is invalid.
       taskInfo.done(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,14 @@ class AsynchronouslyCreatedResourcePool<
     this.readyItems.delete(item);
   }
 
+  has (item: T) {
+    return this.pendingItems.has(item) || this.readyItems.has(item);
+  }
+
+  getAnyWorker () {
+    return [...Array.from(this.readyItems), ...Array.from(this.pendingItems)][0];
+  }
+
   findAvailable () : T | null {
     let minUsage = this.maximumUsage;
     let candidate = null;
@@ -467,7 +475,7 @@ class WorkerInfo extends AsynchronouslyCreatedResource {
 
     try {
       this.port.postMessage(message, taskInfo.transferList);
-    } catch (err) {
+    } catch (err: any) {
       // This would mostly happen if e.g. message contains unserializable data
       // or transferList is invalid.
       taskInfo.done(err);
@@ -1012,32 +1020,39 @@ class Piscina extends EventEmitterAsyncResource {
   }
 
   run (task : any, options : RunOptions = kDefaultRunOptions) {
-    if (options === null || typeof options !== 'object') {
-      return Promise.reject(
-        new TypeError('options must be an object'));
+    const [areOptionsValid, error] = Piscina.#validateRunOptions(options);
+    if (!areOptionsValid && error) {
+      return Promise.reject(error);
     }
+
     const {
       transferList,
       filename,
       name,
       signal
     } = options;
-    if (transferList !== undefined && !Array.isArray(transferList)) {
-      return Promise.reject(
-        new TypeError('transferList argument must be an Array'));
-    }
-    if (filename != null && typeof filename !== 'string') {
-      return Promise.reject(
-        new TypeError('filename argument must be a string'));
-    }
-    if (name != null && typeof name !== 'string') {
-      return Promise.reject(new TypeError('name argument must be a string'));
-    }
-    if (signal != null && typeof signal !== 'object') {
-      return Promise.reject(
-        new TypeError('signal argument must be an object'));
-    }
+
     return this.#pool.runTask(task, { transferList, filename, name, signal });
+  }
+
+  runOnWorker (task : any, workerInfo: WorkerInfo, options : RunOptions = kDefaultRunOptions) {
+    const [areOptionsValid, error] = Piscina.#validateRunOptions(options);
+    if (!areOptionsValid && error) {
+      return Promise.reject(error);
+    }
+
+    const {
+      transferList,
+      filename,
+      name,
+      signal
+    } = options;
+
+    if (!workerInfo) {
+      return Promise.reject(new Error('Invalid workerInfo'));
+    }
+
+    return this.#pool.runTask(task, { transferList, filename, name, signal, workerInfo });
   }
 
   broadcastTask (task : any, transferList? : TransferList, filename? : string, signal? : AbortSignalAny) : Promise<any[]>;
@@ -1057,6 +1072,37 @@ class Piscina extends EventEmitterAsyncResource {
 
   destroy () {
     return this.#pool.destroy();
+  }
+
+  static #validateRunOptions (options : RunOptions): [boolean, Error | null] {
+    if (options === null || typeof options !== 'object') {
+      return [false, new TypeError('options must be an object')];
+    }
+    const {
+      transferList,
+      filename,
+      name,
+      signal
+    } = options;
+
+    if (transferList !== undefined && !Array.isArray(transferList)) {
+      return [false, new TypeError('transferList argument must be an Array')];
+    }
+    if (filename != null && typeof filename !== 'string') {
+      return [false, new TypeError('filename argument must be a string')];
+    }
+    if (name != null && typeof name !== 'string') {
+      return [false, new TypeError('name argument must be a string')];
+    }
+    if (signal != null && typeof signal !== 'object') {
+      return [false, new TypeError('signal argument must be an object')];
+    }
+
+    return [true, null];
+  }
+
+  getAnyWorker () : WorkerInfo {
+    return this.#pool.workers.getAnyWorker();
   }
 
   get options () : FilledOptions {

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -68,6 +68,16 @@ test('broadcasting works', async ({ same }) => {
   same(result, [42, 42, 42, 42]);
 });
 
+test('runOnWorker works', async ({ same }) => {
+  const worker = new Piscina({
+    minThreads: 4,
+    maxThreads: 4,
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+  const result = await worker.runOnWorker('Promise.resolve(42)', worker.getAnyWorker());
+  same(result, 42);
+});
+
 test('filename can be provided while posting', async ({ equal }) => {
   const worker = new Piscina();
   const result = await worker.runTask(


### PR DESCRIPTION
Before I spend any work polishing this, I thought I'd timebox myself and actually put this out for feedback.

We've been talking about moving the plugin server towards a container orchestration system, where we coordinate across server instances. 

However, there are enough optimizations we could make by better allocating resources across threads within the same instance.

For example: the plugins schedule.

This is redlocked so that we only run it once yet we load the schedule on all threads, which slows us down on deploys. 

<img width="1455" alt="Screenshot 2022-02-18 at 13 35 49" src="https://user-images.githubusercontent.com/38760734/154703975-5704290e-fbb0-4aab-82b4-5ce3f8be69dc.png">

What if we allocated one thread per server to handle the schedule? It can handle everything else too - but if we experience slowdowns from a scheduled plugin, or we've just freshly deployed, we won't slow down the entire instance because of it.

If we could pick a worker and always send all scheduled tasks to it (e.g. via the proposed `runOnWorker`), we might be able to improve performance and unlock some nice future use cases too.

WDYT @mariusandra ?